### PR TITLE
Add support to better display message based on its type.

### DIFF
--- a/WPML_Email_Log_List.php
+++ b/WPML_Email_Log_List.php
@@ -198,7 +198,11 @@ class Email_Logging_ListTable extends \WP_List_Table {
 		if ( empty( $item['message'] ) ) {
 			return '';
 		}
-		$content = $this->sanitize_message( $this->render_mail( $item ) );
+		if(strstr($item['headers'],"Content-Type: text/html")){
+			$content = $this->render_mail( $item );
+		} else {
+			$content = "<pre>".$this->sanitize_message( $this->render_mail( $item ) )."</pre>";
+		}
 		$message = '<a class="wp-mail-logging-view-message button button-secondary" href="#" data-message="' . htmlentities( $content )  . '">View</a>';
 		return $message;
 	}

--- a/css/modal.css
+++ b/css/modal.css
@@ -2,7 +2,7 @@
   display: none;
 }
 #wp-mail-logging-modal-backdrop {
-  background: none repeat scroll 0 0 #000000;
+  background: none repeat scroll 0 0 #000;
   bottom: 0;
   left: 0;
   min-height: 360px;
@@ -13,7 +13,7 @@
   z-index: 159900;
 }
 #wp-mail-logging-modal-content {
-  background: none repeat scroll 0 0 #ffffff;
+  background: none repeat scroll 0 0 #fff;
   bottom: 0;
   left: 0;
   margin: auto;
@@ -33,8 +33,8 @@
   z-index: 300010;
 }
 #wp-mail-logging-modal-content-header {
-  background-color: #eeeeee;
-  border-bottom: 1px solid #cccccc;
+  background-color: #eee;
+  border-bottom: 1px solid #ccc;
   left: 0;
   padding: 15px 10px 15px 10px;
   position: absolute;
@@ -74,13 +74,16 @@
   position: relative;
   padding: 15px;
 }
+#wp-mail-logging-modal-content-body-content > pre {
+  word-wrap: break-word;
+}
 #wp-mail-logging-modal-content-body .title {
   font-weight: bold;
   display: block;
 }
 #wp-mail-logging-modal-content-footer {
-  background-color: #eeeeee;
-  border-top: 1px solid #cccccc;
+  background-color: #eee;
+  border-top: 1px solid #ccc;
   bottom: 0;
   left: 0;
   padding: 15px 10px 15px 10px;

--- a/css/modal.less
+++ b/css/modal.less
@@ -103,6 +103,10 @@
 			&-content {
 				position: relative;
 				padding: @body-content-padding;
+                                
+                                & > pre {
+                                    word-wrap: break-word;
+                                }
 			}
 			
 			& .title {


### PR DESCRIPTION
For better formatting text messages we use 
    <pre></pre>
Html messages can be displayed as is, because this messages was generated by our WordPress.