### PR TITLE
Plugin header : text domain is wrong

### DIFF
--- a/wp-mail-logging.php
+++ b/wp-mail-logging.php
@@ -7,7 +7,7 @@
    Author: Christian Z&ouml;ller
    Author URI: http://no3x.de/
    Description: Logs each email sent by WordPress.
-   Text Domain: wpml
+   Text Domain: wp-mail-logging
    License: GPLv3
   */
 


### PR DESCRIPTION
Hi,

The text domain variable inside plugin header does not correspond to the domain you use when you call `load_plugin_textdomain` : https://github.com/No3x/wp-mail-logging/blob/9a9b687d7a1f9147486e9eb53424534b07a76d30/wp-mail-logging.php#L73