### PR TITLE
Cache table installation state to avoid duplicate queries

### DIFF
--- a/WPML_InstallIndicator.php
+++ b/WPML_InstallIndicator.php
@@ -28,6 +28,8 @@ class WPML_InstallIndicator extends WPML_OptionsManager {
 
     const optionInstalled = '_installed';
     const optionVersion = '_version';
+    const CACHE_GROUP = 'wp_mail_logging';
+    const CACHE_INSTALLED_KEY = 'installed';
 
     /**
      * Checks if the plugin is installed.
@@ -38,7 +40,7 @@ class WPML_InstallIndicator extends WPML_OptionsManager {
 
         // We don't use the cached value, only its presence.
         // This is because we never cache not installed state.
-        wp_cache_get('installed', 'No3x/wpml', false, $installed);
+        wp_cache_get(self::CACHE_INSTALLED_KEY, self::CACHE_GROUP, false, $installed);
         if (!$installed) {
             global $wpdb;
 
@@ -47,7 +49,7 @@ class WPML_InstallIndicator extends WPML_OptionsManager {
             $installed = (bool) $query;
 
             if ($installed) {
-                wp_cache_set('installed', true, 'No3x/wpml', 3600);
+                wp_cache_set(self::CACHE_INSTALLED_KEY, true, self::CACHE_GROUP, 3600);
             }
         }
         return $installed;

--- a/WPML_InstallIndicator.php
+++ b/WPML_InstallIndicator.php
@@ -34,10 +34,23 @@ class WPML_InstallIndicator extends WPML_OptionsManager {
      * @return bool indicating if the plugin is installed already
      */
     public function isInstalled() {
-        global $wpdb;
-        $mails = $this->getTablename('mails');
-        $query = $wpdb->query("SHOW TABLES LIKE \"$mails\"");
-        return (bool) $query;
+        $installed = false;
+
+        // We don't use the cached value, only its presence.
+        // This is because we never cache not installed state.
+        wp_cache_get('installed', 'No3x/wpml', false, $installed);
+        if (!$installed) {
+            global $wpdb;
+
+            $mails = $this->getTablename('mails');
+            $query = $wpdb->query("SHOW TABLES LIKE \"$mails\"");
+            $installed = (bool) $query;
+
+            if ($installed) {
+                wp_cache_set('installed', true, 'No3x/wpml', 3600);
+            }
+        }
+        return $installed;
     }
 
     /**

--- a/WPML_Plugin.php
+++ b/WPML_Plugin.php
@@ -55,7 +55,7 @@ class WPML_Plugin extends WPML_LifeCycle {
 				`attachments` VARCHAR(800) NOT NULL DEFAULT '0',
 				`error` VARCHAR(400) NULL DEFAULT '',
 				`plugin_version` VARCHAR(200) NOT NULL DEFAULT '0',
-				PRIMARY KEY (`mail_id`) 
+				PRIMARY KEY (`mail_id`)
 			) DEFAULT CHARACTER SET = utf8 DEFAULT COLLATE utf8_general_ci;");
     }
 
@@ -68,6 +68,8 @@ class WPML_Plugin extends WPML_LifeCycle {
         global $wpdb;
         $tableName = WPML_Plugin::getTablename('mails');
         $wpdb->query("DROP TABLE IF EXISTS `$tableName`");
+        // Remove the cache option indicating tables are installed
+        wp_cache_delete('installed', 'No3x/wpml');
     }
 
     /**

--- a/WPML_Plugin.php
+++ b/WPML_Plugin.php
@@ -69,7 +69,7 @@ class WPML_Plugin extends WPML_LifeCycle {
         $tableName = WPML_Plugin::getTablename('mails');
         $wpdb->query("DROP TABLE IF EXISTS `$tableName`");
         // Remove the cache option indicating tables are installed
-        wp_cache_delete('installed', 'No3x/wpml');
+        wp_cache_delete(parent::CACHE_INSTALLED_KEY, parent::CACHE_GROUP);
     }
 
     /**


### PR DESCRIPTION
When 'SHOW TABLES LIKE ...' succeeds (i.e. WPML is installed), set a
cache value 'installed' to true. This means that once WPML is installed
to the database, there will be no more repeated 'SHOW TABLES LIKE ..'
queries (previously: multiple times each page request) executed against
the database.

The version checks are left untouched, they should still be used as-is
in conjunction with `isInstalled()`. This only caches the installation
state of the tables in the database (for any version) to optimize the
common case of "yes, they're installed."

The cache variable is unset on uninstall so this should play nice with
tests and with users uninstalling then wishing to reinstall the plugin
within the default cache variable expiry window (1 hour).

Closes #71.